### PR TITLE
Title cutoff on y-axis or overlaps with tick label

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1478,6 +1478,7 @@ plots.doAutoMargin = function(gd) {
     var layers = ['yaxis', 'xaxis', 'xaxis2']//these are the only layers I want to adjust the layout margin
     var axes = Plotly.Axes;
     var measurementKeys = {'left': 'width', 'right': 'width', 'top': 'height','bottom': 'height'};
+    var yAxisTitleHeight = 0;
 
     layers.forEach(function(layerName) {
         var axisLayer = fullLayout[layerName];
@@ -1504,13 +1505,14 @@ plots.doAutoMargin = function(gd) {
             if(adjustedMargin == 0){
                 adjustedMargin = 10;//we need to account for hover title. Whenever the user zooms in too much and the x-axis is hidden and they hover over a data point
             }
-            
+
             if(axisName == 'y'){
               //Most likely the text will be rotated 90degees on the Y-axis.. in that case we care about the width of the text.
               //So the width of the title + the largest tick's width would give us the adjusted margin 
                 adjustedMargin += measurement.width;
+                yAxisTitleHeight = measurement.height > yAxisTitleHeight ? measurement.height : yAxisTitleHeight;
             } else {
-                //rotated height of tick + height of title
+              //rotated height of tick + height of title
                 adjustedMargin += measurement.height;
             }
 
@@ -1544,6 +1546,7 @@ plots.doAutoMargin = function(gd) {
         adjustBottomMargin.push(fullLayout.margin.b || 0);
     }
 
+
     adjustLeftMargin.push(0);
     adjustRightMargin.push(0);
     adjustTopMargin.push(0);
@@ -1557,6 +1560,17 @@ plots.doAutoMargin = function(gd) {
         mt = Math.max.apply(null, adjustTopMargin),
         mb = Math.max.apply(null, adjustBottomMargin),
         pm = fullLayout._pushmargin;
+
+    
+    if(mt == 0){
+        //So we need to account for the case where the title's height cannot fit in the allotted space after the top & bottom margin is removed from
+        // the height of the layout. In that case we need to add enough space to render the title.. the issue is that the user needs to provide 
+        //sufficent layout height in order to render the plot.. but lets do what we can.
+        var remainingHeight = Math.round(fullLayout.height) - (mt + mb);
+        if(remainingHeight < yAxisTitleHeight){
+            mt += (yAxisTitleHeight - remainingHeight);
+        }
+    }
 
     if(fullLayout.margin.autoexpand !== false) {
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1433,6 +1433,38 @@ plots.autoMargin = function(gd, id, o) {
     }
 };
 
+plots.calculateTextMeasurements = function(text, font, angle, axisName) {
+    if(typeof(font) !== "string"){
+        font = font.size + "px "+  font.family;
+    }
+
+    var tag = document.createElement("div");
+    tag.style.position = "absolute";
+    tag.style.left = "-999em";
+    tag.style.whiteSpace = "nowrap";
+    tag.style.font = font;
+    tag.innerHTML = text;
+    
+
+    if(angle == 'auto' && axisName == 'x'){
+        angle = 90
+    }
+
+    if(!isNaN(+angle)){
+        tag.style.transform = 'rotate('+ angle+'deg)';
+    }
+
+    document.body.appendChild(tag);
+    var rec = tag.getBoundingClientRect();
+
+    var width = rec.width;
+    var height = rec.height;
+
+    document.body.removeChild(tag);
+
+    return {width: width, height: height};
+}
+
 plots.doAutoMargin = function(gd) {
     var fullLayout = gd._fullLayout;
     if(!fullLayout._size) fullLayout._size = {};
@@ -1441,13 +1473,84 @@ plots.doAutoMargin = function(gd) {
     var gs = fullLayout._size,
         oldmargins = JSON.stringify(gs);
 
+    //Lets adjust the layout margin to account for the axis tick label positions to prevent overflow issues and overlapping of labels
+    var adjustLeftMargin = [], adjustRightMargin = [] , adjustTopMargin = [], adjustBottomMargin = [];
+    var layers = ['yaxis', 'xaxis', 'xaxis2']//these are the only layers I want to adjust the layout margin
+    var axes = Plotly.Axes;
+    var measurementKeys = {'left': 'width', 'right': 'width', 'top': 'height','bottom': 'height'};
+
+    layers.forEach(function(layerName) {
+        var axisLayer = fullLayout[layerName];
+        if(axisLayer && axisLayer._length){
+            var axisRange = axes.calcTicks(axisLayer);
+            var largestVal = {text:''}
+            var axisName = axisLayer._id.charAt(0);
+
+            //find the largest label. this can be optimize.. but considering that the data is small; I'm not going to worry about it
+            for(var i=0; i<axisRange.length; i++ ){
+                if(axisRange[i].text.length >= largestVal.text.length){
+                  largestVal = axisRange[i];
+                }
+            }
+
+            var measurement = plots.calculateTextMeasurements(largestVal.text, axisLayer.tickfont, axisLayer.tickangle, axisName);
+            //separate for readablity
+            var key  = measurementKeys[axisLayer.side || (axisName =='x'? 'bottom': 'left')];
+            var adjustedMargin = measurement[key];
+            //Ideally we should calculate the title's deminsion base on its angle.. but I dont know where that info is stored.. so lets use the axis name to determine its angle
+            var angle = (axisName == 'y'? 90: 0);
+            measurement = plots.calculateTextMeasurements(axisLayer.title, axisLayer.titlefont, angle);
+            if(axisName == 'y'){
+              //Most likely the text will be rotated 90degees on the Y-axis.. in that case we care about the width of the text.
+              //So the width of the title + the largest tick's width would give us the adjusted margin 
+                adjustedMargin += measurement.width;
+            } else {
+                //rotated height of tick + height of title
+                adjustedMargin += measurement.height;
+            }
+
+            switch(axisLayer.side){
+                case 'left':
+                    adjustLeftMargin.push(adjustedMargin);
+                    break;
+                case 'right':
+                    adjustRightMargin.push(adjustedMargin);
+                    break;
+                case 'top':
+                    adjustTopMargin.push(adjustedMargin);
+                    break;
+                case 'bottom':
+                    adjustBottomMargin.push(adjustedMargin);
+                    break;
+            }
+        }
+    });
+
+    if(!adjustLeftMargin.length){
+        adjustLeftMargin.push(fullLayout.margin.l || 0);
+    }
+    if(!adjustRightMargin.length){
+        adjustRightMargin.push(fullLayout.margin.r || 0);
+    }
+    if(!adjustTopMargin.length){
+        adjustTopMargin.push(fullLayout.margin.t || 0);
+    }
+    if(!adjustBottomMargin.length){
+        adjustBottomMargin.push(fullLayout.margin.b || 0);
+    }
+
+    adjustLeftMargin.push(0);
+    adjustRightMargin.push(0);
+    adjustTopMargin.push(0);
+    adjustBottomMargin.push(0);
+
     // adjust margins for outside components
     // fullLayout.margin is the requested margin,
     // fullLayout._size has margins and plotsize after adjustment
-    var ml = Math.max(fullLayout.margin.l || 0, 0),
-        mr = Math.max(fullLayout.margin.r || 0, 0),
-        mt = Math.max(fullLayout.margin.t || 0, 0),
-        mb = Math.max(fullLayout.margin.b || 0, 0),
+    var ml = Math.max.apply(null, adjustLeftMargin),
+        mr = Math.max.apply(null, adjustRightMargin),
+        mt = Math.max.apply(null, adjustTopMargin),
+        mb = Math.max.apply(null, adjustBottomMargin),
         pm = fullLayout._pushmargin;
 
     if(fullLayout.margin.autoexpand !== false) {

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1500,6 +1500,11 @@ plots.doAutoMargin = function(gd) {
             //Ideally we should calculate the title's deminsion base on its angle.. but I dont know where that info is stored.. so lets use the axis name to determine its angle
             var angle = (axisName == 'y'? 90: 0);
             measurement = plots.calculateTextMeasurements(axisLayer.title, axisLayer.titlefont, angle);
+            
+            if(adjustedMargin == 0){
+                adjustedMargin = 10;//we need to account for hover title. Whenever the user zooms in too much and the x-axis is hidden and they hover over a data point
+            }
+            
             if(axisName == 'y'){
               //Most likely the text will be rotated 90degees on the Y-axis.. in that case we care about the width of the text.
               //So the width of the title + the largest tick's width would give us the adjusted margin 


### PR DESCRIPTION
Address the following issues where the title overlapped the y-axis tick labels or a portion of the title was cutoff
https://github.com/plotly/plotly.js/issues/1504
https://github.com/plotly/plotly.js/issues/296

Might also address:
https://github.com/plotly/plotly.js/issues/1594

Thanks for your interest in plotly.js!

Developers are strongly encouraged to first make a PR to their own plotly.js fork and ask one of the maintainers to review the modifications there. Once the pull request is deemed satisfactory, the developer will be asked to make a pull request to the main plotly.js repo and may be asked to squash some commits before doing so.

Before opening a pull request, developer should: 

- `git rebase` their local branch off the latest `master`,
- make sure to **not** `git add` the `dist/` folder (the `dist/` is updated only on verion bumps),
- write an overview of what the PR attempts to do,
- select the _Allow edits from maintainers_ option (see this [article](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for more details).

Note that it is forbidden to force push (i.e. `git push -f`) to remote branches associated with opened pull requests. Force pushes make it hard for maintainers to keep track of updates. Therefore, if required, please `git merge master` into your PR branch instead of `git rebase master`.
